### PR TITLE
Feature/configuration disable movement

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -13,6 +13,10 @@
 		</entry>
 	</group>
 	<group name="Movement">
+		<entry name="enableMovement" type="Bool">
+			<label>Movement enabled</label>
+			<default>true</default>
+		</entry>
 		<entry name="speed" type="Double">
 			<label>Movement speed</label>
 			<default>1.3</default>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -11,6 +11,10 @@
 			<label>Path to custom image</label>
 			<default></default>
 		</entry>
+		<entry name="mirrorImage" type="Bool">
+			<label>Mirror image</label>
+			<default>false</default>
+		</entry>
 	</group>
 	<group name="Movement">
 		<entry name="enableMovement" type="Bool">
@@ -25,13 +29,13 @@
 			<label>Enable idling</label>
 			<default>false</default>
 		</entry>
-		<entry name="enableFlipping" type="Bool">
-			<label>Enable image flipping</label>
-			<default>true</default>
-		</entry>
 		<entry name="idleProbability" type="Int">
 			<label>Probability of becoming idle (percentage)</label>
 			<default>13</default>
+		</entry>
+		<entry name="enableFlipping" type="Bool">
+			<label>Enable image flipping</label>
+			<default>true</default>
 		</entry>
 	</group>
 </kcfg>

--- a/package/contents/ui/config/configImage.qml
+++ b/package/contents/ui/config/configImage.qml
@@ -12,19 +12,11 @@ Page {
 
 	property alias cfg_imageSize: imageSizeSpinBox.value
 	property alias cfg_customImagePath: customImageField.text
+	property alias cfg_mirrorImage: mirrorImageCheckBox.checked
 
 	property int cfg_imageSizeDefault: 128
 	property string cfg_customImagePathDefault: ""
-
-	property alias cfg_speed: speedSlider.value
-	property alias cfg_enableRandomIdle: enableRandomIdleCheckBox.checked
-	property alias cfg_enableFlipping: enableFlippingCheckBox.checked
-	property alias cfg_idleProbability: idleProbabilitySpinBox.value
-
-	property double cfg_speedDefault: 2.0
-	property bool cfg_enableRandomIdleDefault: false
-	property bool cfg_enableFlippingDefault: true
-	property int cfg_idleProbabilityDefault: 30
+	property bool cfg_mirrorImageDefault: false
 
 	// fixme: Of course it's not robust enough.
 	readonly property bool isAnimated: customImageField.text.toLowerCase().endsWith(".gif")
@@ -89,24 +81,23 @@ Page {
 					Layout.preferredHeight: 200
 					source: previewContainer.imagePath
 					playing: true
+					mirror: cfg_mirrorImage
 
 					readonly property bool isImageReady: status === AnimatedImage.Ready
 
 					onStatusChanged: playing = (status === AnimatedImage.Ready)
 				}
 			}
+
+			CheckBox {
+				id: mirrorImageCheckBox
+				checked: cfg_mirrorImage
+				Kirigami.FormData.label: i18n("Mirror Image:")
+			}
 		}
 
 		Item {
 			Layout.fillHeight: true
-		}
-
-		Item {
-			visible: false
-			Slider { id: speedSlider; value: cfg_speedDefault }
-			CheckBox { id: enableRandomIdleCheckBox; checked: cfg_enableRandomIdleDefault }
-			CheckBox { id: enableFlippingCheckBox; checked: cfg_enableFlippingDefault }
-			SpinBox { id: idleProbabilitySpinBox; value: cfg_idleProbabilityDefault }
 		}
 	}
 }

--- a/package/contents/ui/config/configMovement.qml
+++ b/package/contents/ui/config/configMovement.qml
@@ -9,11 +9,13 @@ Page {
 	id: movementPage
 	title: i18n("Movement")
 
+	property alias cfg_enableMovement: enableMovementCheckBox.checked
 	property alias cfg_speed: speedSlider.value
 	property alias cfg_enableRandomIdle: enableRandomIdleCheckBox.checked
 	property alias cfg_enableFlipping: enableFlippingCheckBox.checked
 	property alias cfg_idleProbability: idleProbabilitySpinBox.value
 
+	property bool cfg_enableMovementDefault: true
 	property double cfg_speedDefault: 2.0
 	property bool cfg_enableRandomIdleDefault: false
 	property bool cfg_enableFlippingDefault: true
@@ -32,6 +34,12 @@ Page {
 		Kirigami.FormLayout {
 			Layout.fillWidth: true
 
+			CheckBox {
+				id: enableMovementCheckBox
+				text: i18n("Enabled")
+				checked: cfg_enableMovementDefault
+			}
+
 			RowLayout {
 				Kirigami.FormData.label: i18n("Speed:")
 				Layout.fillWidth: true
@@ -43,6 +51,7 @@ Page {
 					to: 10.0
 					stepSize: 0.1
 					value: cfg_speedDefault
+					enabled: enableMovementCheckBox.checked
 				}
 
 				Label {
@@ -57,6 +66,7 @@ Page {
 				Kirigami.FormData.label: i18n("Random Idle:")
 				text: i18n("Enabled")
 				checked: cfg_enableRandomIdleDefault
+				enabled: enableMovementCheckBox.checked
 			}
 
 			CheckBox {
@@ -64,15 +74,16 @@ Page {
 				Kirigami.FormData.label: i18n("Image Flipping:")
 				text: i18n("Enabled")
 				checked: cfg_enableFlippingDefault
+				enabled: enableMovementCheckBox.checked
 			}
 
 			SpinBox {
 				id: idleProbabilitySpinBox
-				Kirigami.FormData.label: i18n("Idle Probability:")
+				Kirigami.FormData.label: i18n("Idle Probability (%):")
 				from: 1
 				to: 100
 				value: cfg_idleProbabilityDefault
-				enabled: enableRandomIdleCheckBox.checked
+				enabled: enableMovementCheckBox.checked && enableRandomIdleCheckBox.checked
 
 				Layout.fillWidth: true
 				Layout.maximumWidth: Kirigami.Units.gridUnit * 10

--- a/package/contents/ui/config/configMovement.qml
+++ b/package/contents/ui/config/configMovement.qml
@@ -12,20 +12,14 @@ Page {
 	property alias cfg_enableMovement: enableMovementCheckBox.checked
 	property alias cfg_speed: speedSlider.value
 	property alias cfg_enableRandomIdle: enableRandomIdleCheckBox.checked
-	property alias cfg_enableFlipping: enableFlippingCheckBox.checked
 	property alias cfg_idleProbability: idleProbabilitySpinBox.value
+	property alias cfg_enableFlipping: enableFlippingCheckBox.checked
 
 	property bool cfg_enableMovementDefault: true
 	property double cfg_speedDefault: 2.0
 	property bool cfg_enableRandomIdleDefault: false
-	property bool cfg_enableFlippingDefault: true
 	property int cfg_idleProbabilityDefault: 30
-
-	property alias cfg_imageSize: imageSizeSpinBox.value
-	property alias cfg_customImagePath: customImageField.text
-
-	property int cfg_imageSizeDefault: 128
-	property string cfg_customImagePathDefault: ""
+	property bool cfg_enableFlippingDefault: true
 
 	ColumnLayout {
 		anchors.fill: parent
@@ -36,8 +30,9 @@ Page {
 
 			CheckBox {
 				id: enableMovementCheckBox
+				Kirigami.FormData.label: i18n("Overall Movement:")
 				text: i18n("Enabled")
-				checked: cfg_enableMovementDefault
+				checked: movementPage.cfg_enableMovementDefault
 			}
 
 			RowLayout {
@@ -69,14 +64,6 @@ Page {
 				enabled: enableMovementCheckBox.checked
 			}
 
-			CheckBox {
-				id: enableFlippingCheckBox
-				Kirigami.FormData.label: i18n("Image Flipping:")
-				text: i18n("Enabled")
-				checked: cfg_enableFlippingDefault
-				enabled: enableMovementCheckBox.checked
-			}
-
 			SpinBox {
 				id: idleProbabilitySpinBox
 				Kirigami.FormData.label: i18n("Idle Probability (%):")
@@ -88,16 +75,18 @@ Page {
 				Layout.fillWidth: true
 				Layout.maximumWidth: Kirigami.Units.gridUnit * 10
 			}
+
+			CheckBox {
+				id: enableFlippingCheckBox
+				Kirigami.FormData.label: i18n("Image Flipping Based on the Direction:")
+				text: i18n("Enabled")
+				checked: cfg_enableFlippingDefault
+				enabled: enableMovementCheckBox.checked
+			}
 		}
 
 		Item {
 			Layout.fillHeight: true
-		}
-
-		Item {
-			visible: false
-			SpinBox { id: imageSizeSpinBox; value: cfg_imageSizeDefault }
-			TextField { id: customImageField; text: cfg_customImagePathDefault }
 		}
 	}
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -9,15 +9,17 @@ PlasmoidItem {
 	id: root
 
 	property int nyancatSize: plasmoid.configuration.imageSize
+	property string imageSource: plasmoid.configuration.customImagePath || "../images/nyancat.gif"
+	property bool enableMovement: plasmoid.configuration.enableMovement || true
 	property double speed: plasmoid.configuration.speed
+	property bool enableRandomIdle: plasmoid.configuration.enableRandomIdle
+	property bool enableFlipping: plasmoid.configuration.enableFlipping
+	property int idleProbability: plasmoid.configuration.idleProbability
+
 	property point targetPosition: Qt.point(0, 0)
 	property bool movingRight: true
-	property string imageSource: plasmoid.configuration.customImagePath || "../images/nyancat.gif"
 	property bool isIdle: false
 	property bool wasIdleBefore: false
-	property bool enableRandomIdle: plasmoid.configuration.enableRandomIdle
-	property int idleProbability: plasmoid.configuration.idleProbability
-	property bool enableFlipping: plasmoid.configuration.enableFlipping
 
 	// fixme: Of course it's not robust enough.
 	readonly property bool isAnimated: imageSource.toLowerCase().endsWith(".gif")
@@ -63,14 +65,16 @@ PlasmoidItem {
 			}
 
 			Component.onCompleted: {
-				container.moveToRandomPosition()
+				if (enableMovement) {
+					container.moveToRandomPosition()
+				}
 			}
 		}
 
 		Timer {
 			id: moveTimer
+			running: enableMovement
 			interval: 20
-			running: true
 			repeat: true
 
 			onTriggered: {
@@ -96,6 +100,7 @@ PlasmoidItem {
 
 		Timer {
 			id: idleTimer
+			running: enableMovement
 			interval: 2000
 			repeat: false
 			onTriggered: {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -10,7 +10,8 @@ PlasmoidItem {
 
 	property int nyancatSize: plasmoid.configuration.imageSize
 	property string imageSource: plasmoid.configuration.customImagePath || "../images/nyancat.gif"
-	property bool enableMovement: plasmoid.configuration.enableMovement || true
+	property bool mirrorImage: plasmoid.configuration.mirrorImage
+	property bool enableMovement: plasmoid.configuration.enableMovement
 	property double speed: plasmoid.configuration.speed
 	property bool enableRandomIdle: plasmoid.configuration.enableRandomIdle
 	property bool enableFlipping: plasmoid.configuration.enableFlipping
@@ -56,9 +57,12 @@ PlasmoidItem {
 			y: 0
 
 			AnimatedImage {
+				property bool baseMirror: root.enableFlipping ? !root.movingRight : false
+				property bool toMirror: root.mirrorImage ? !baseMirror : baseMirror
+
 				anchors.fill: parent
 				source: root.imageSource
-				mirror: root.enableFlipping ? !root.movingRight : false
+				mirror: toMirror
 				playing: true
 
 				onStatusChanged: playing = (status === AnimatedImage.Ready)

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -3,7 +3,7 @@
 	"KPlugin": {
 		"Id": "xyz.attacktive.nyan-wanderer",
 		"Name": "Nyan Wanderer",
-		"Version": "1.0.8",
+		"Version": "1.1.0",
 		"Description": "A cute Nyan Cat that wanders around your desktop",
 		"Category": "Fun and Games",
 		"Icon": "animal-symbolic",


### PR DESCRIPTION
Adds two configuration options:
1. disable movement; Nyan Cat doesn't move nor flip
2. mirror Nyan Cat image horizontally

It also fixes inconsistent setting between configurations tabs.

It resolves https://github.com/Attacktive/nyan-wanderer/issues/26.