### PR TITLE
chore: rename plasmoid to Roameow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(nyan-wanderer)
+project(roameow)
 
 find_package(ECM 1.4.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Nyan Wanderer
+# Roameow
 
-[![CodeFactor](https://www.codefactor.io/repository/github/attacktive/nyan-wanderer/badge)](https://www.codefactor.io/repository/github/attacktive/nyan-wanderer)
-[![Release](https://github.com/Attacktive/nyan-wanderer/actions/workflows/release.yaml/badge.svg)](https://github.com/Attacktive/nyan-wanderer/actions/workflows/release.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/attacktive/roameow-plasma/badge)](https://www.codefactor.io/repository/github/attacktive/roameow-plasma)
+[![Release](https://github.com/Attacktive/Roameow-plasma/actions/workflows/release.yaml/badge.svg)](https://github.com/Attacktive/Roameow-plasma/actions/workflows/release.yaml)
 
 A fun Plasma 6 widget that features an animated nyancat wandering around your desktop!
 

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -2,7 +2,7 @@
 	"KPackageStructure": "Plasma/Applet",
 	"KPlugin": {
 		"Id": "xyz.attacktive.nyan-wanderer",
-		"Name": "Nyan Wanderer",
+		"Name": "Roameow",
 		"Version": "1.2.3",
 		"Description": "A cute Nyan Cat that wanders around your desktop",
 		"Category": "Fun and Games",
@@ -13,7 +13,7 @@
 				"Email": "tribute2pantera@gmail.com"
 			}
 		],
-		"Website": "https://github.com/attacktive/wandering-nyancat",
+		"Website": "https://github.com/Attacktive/Roameow-plasma",
 		"License": "MIT",
 		"EnabledByDefault": true
 	},

--- a/package/translate/merge
+++ b/package/translate/merge
@@ -12,7 +12,7 @@ pushd "$SCRIPT_PATH" || exit
 
 plasmoidName='xyz.attacktive.nyan-wanderer'
 widgetName="${plasmoidName##*.}" # Strip namespace
-website='https://github.com/Attacktive/nyan-wanderer'
+website='https://github.com/Attacktive/Roameow-plasma'
 bugAddress="$website"
 packageRoot="$SCRIPT_PATH/.." # Root of translatable sources
 

--- a/package/translate/po/de.po
+++ b/package/translate/po/de.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/en.po
+++ b/package/translate/po/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/es.po
+++ b/package/translate/po/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: es\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/fr.po
+++ b/package/translate/po/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/it.po
+++ b/package/translate/po/it.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/ja.po
+++ b/package/translate/po/ja.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: ja\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/ko.po
+++ b/package/translate/po/ko.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: ko\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/pt.po
+++ b/package/translate/po/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: pt\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/ru.po
+++ b/package/translate/po/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: ru\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/po/zh.po
+++ b/package/translate/po/zh.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-27 15:05+0900\n"
 "Language: zh_CN\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/package/translate/template.pot
+++ b/package/translate/template.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: nyan-wanderer\n"
-"Report-Msgid-Bugs-To: https://github.com/Attacktive/nyan-wanderer\n"
+"Report-Msgid-Bugs-To: https://github.com/Attacktive/Roameow-plasma\n"
 "POT-Creation-Date: 2025-04-29 14:20+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
Rebrands the plasmoid's **display name** and repo URLs from "Nyan Wanderer" to **Roameow**, unifying with the macOS Roameow app.

## What changed
- `package/metadata.json`: `Name` → "Roameow"; fixed `Website` (was pointing at a stale, non-existent `wandering-nyancat` repo) → this repo
- `README.md`: title + CodeFactor / Release badge URLs
- `CMakeLists.txt`: `project()` name → `roameow`
- Translation files (`merge`, `template.pot`, 10× `.po`): repo URL in `website` / `Report-Msgid-Bugs-To`

## Intentionally NOT changed
- The plugin **Id** `xyz.attacktive.nyan-wanderer` and everything keyed to it (install path, `.plasmoid` artifact name, `plasma_applet_…` translation domain, `plasmoidviewer` target). Keeping the Id means existing KDE Store installs keep updating in place and preserve their settings.
- Default-asset literals (`nyancat.gif`, `nyancatSize`, "Nyan Cat" labels) — Roameow's default pet is still a nyancat.

## Follow-up (outside this PR)
- Rename the GitHub repo → `Roameow-plasma`
- Rename the local working dir, and move the Claude Code project dir to preserve auto-memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)