### PR TITLE
bugfix: harden install.sh and test-i18n.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 rm -fr build
 mkdir build

--- a/test-i18n.sh
+++ b/test-i18n.sh
@@ -1,5 +1,7 @@
-sh package/translate/merge
-sh package/translate/build
+#!/usr/bin/env bash
+
+bash package/translate/merge
+bash package/translate/build
 
 LANGUAGE='ja_JP'
 LANG='ja_JP.UTF-8'


### PR DESCRIPTION
Two small shell-script robustness fixes, ahead of the store push.

### `install.sh` — fail fast (#67)
Added `set -euo pipefail`. Without it, a failed `cmake`/`make` still fell through to `make install`, so the script could install a half-built package and exit `0`. Safe here: the only variable is `$HOME` (always set), and there are no pipelines.

### `test-i18n.sh` — use bash, not sh (#69)
`sh package/translate/{merge,build}` ran two **bash** scripts under `/bin/sh` (dash on Ubuntu), which mishandles their `$'\033[…'` color escapes. Now invoked with `bash`. Also added a `#!/usr/bin/env bash` shebang to `test-i18n.sh` itself, since it's executable and run directly.

The `plasmoidviewer -a 'xyz.attacktive.nyan-wanderer'` line is left as-is — that's the intentionally-kept plugin Id.

Verified: `bash -n` clean on both files.

Closes #67
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)