### PR TITLE
chore: prepare 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/attacktive/roameow-plasma/badge)](https://www.codefactor.io/repository/github/attacktive/roameow-plasma)
 [![Release](https://github.com/Attacktive/Roameow-plasma/actions/workflows/release.yaml/badge.svg)](https://github.com/Attacktive/Roameow-plasma/actions/workflows/release.yaml)
 
-A fun Plasma 6 widget that features an animated nyancat wandering around your desktop!
+A fun Plasma 6 widget that features an animated Nyan Cat roaming around your desktop!
 
 It's completely useless by design. 😏
 

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -3,8 +3,8 @@
 	"KPlugin": {
 		"Id": "xyz.attacktive.nyan-wanderer",
 		"Name": "Roameow",
-		"Version": "1.2.3",
-		"Description": "A cute Nyan Cat that wanders around your desktop",
+		"Version": "2.0.0",
+		"Description": "Roameow — your Nyan Cat, roaming the desktop",
 		"Category": "Fun and Games",
 		"Icon": "animal-symbolic",
 		"Authors": [


### PR DESCRIPTION
Prep for the **Roameow 2.0.0** major release.

- `metadata.json`: `Version` 1.2.3 → **2.0.0**
- `metadata.json`: `Description` → **"Roameow — your Nyan Cat, roaming the desktop"** (brand-forward; retires the old "wander" verb in favour of "roam")
- `README.md`: same verb refresh on the tagline

Plugin Id untouched. After merge, tagging `2.0.0` fires the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)