### PR TITLE
bugfix: bundle translations into the released package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           # Adding KDE neon PPA to the containerized Ubuntu because it lacks dependencies for Plasma 6
           echo 'deb [trusted=yes] http://archive.neon.kde.org/user noble main' | sudo tee /etc/apt/sources.list.d/neon.list
           sudo apt update
-          sudo apt install -y kf6-extra-cmake-modules plasma-framework6-dev
+          sudo apt install -y kf6-extra-cmake-modules plasma-framework6-dev gettext
       - name: 'Build Plasmoid'
         run: './install.sh'
       - name: 'Archive Artifacts'

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ It's completely useless by design. 😏
 1. Make sure you have the required dependencies:
 	- Arch Linux
 	```bash
-	$ sudo pacman -S base-devel extra-cmake-modules plasma-sdk
+	$ sudo pacman -S base-devel extra-cmake-modules plasma-sdk gettext
 	```
 	- Ubuntu 24.04
 	```bash
 	# Adding KDE neon PPA to the containerized Ubuntu because it lacks dependencies for Plasma 6
 	$ echo "deb [trusted=yes] http://archive.neon.kde.org/user noble main" | sudo tee /etc/apt/sources.list.d/neon.list
 	$ sudo apt update
-	$ sudo apt install build-essential kf6-extra-cmake-modules plasma-framework6-dev
+	$ sudo apt install build-essential kf6-extra-cmake-modules plasma-framework6-dev gettext
 	```
 
 2. Build and install the widget:

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Compile the .po catalogs into package/contents/locale/ so plasma_install_package bundles them
+bash package/translate/build
+
 rm -fr build
 mkdir build
 pushd build


### PR DESCRIPTION
Fixes **#59** — the widget ships 10 `.po` catalogs, but none reached users: the compiled `.mo` files were only built by the local test helper, never by `install.sh` or CI, so `plasma_install_package` packaged a tree with no `contents/locale/`. Everyone got English — including the 2.0.0 store build.

### Changes
- **`install.sh`** runs `package/translate/build` before the cmake build, so `contents/locale/` exists when `plasma_install_package` copies the package tree.
- **`release.yaml`** installs `gettext` (provides `msgfmt`) so CI can compile the catalogs.
- **`README.md`** adds `gettext` to the Arch and Ubuntu dependency lists.

`contents/locale/` stays git-ignored — it's a build artifact, generated at install time.

### Verified locally (clean rebuild)
| Check | Result |
|---|---|
| `translate/build` | 10/10 `.mo` compiled (incl. `zh`) |
| catalog | valid GNU message catalog, domain `plasma_applet_xyz.attacktive.nyan-wanderer` (matches the plugin Id) |
| temp-prefix `plasma_install_package` | installed tree has 10/10 `.mo` under `contents/locale/` |
| `.plasmoid` zip | contains all 10 locale `.mo` entries |

After merge, a **2.0.1** tag will produce the first `.plasmoid` that actually carries translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)