### PR TITLE
chore: prepare 2.0.1 release

### DIFF
--- a/package/metadata.json
+++ b/package/metadata.json
@@ -3,7 +3,7 @@
 	"KPlugin": {
 		"Id": "xyz.attacktive.nyan-wanderer",
 		"Name": "Roameow",
-		"Version": "2.0.0",
+		"Version": "2.0.1",
 		"Description": "Roameow — your Nyan Cat, roaming the desktop",
 		"Category": "Fun and Games",
 		"Icon": "animal-symbolic",

--- a/package/translate/po/de.po
+++ b/package/translate/po/de.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: German\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"
@@ -45,7 +50,7 @@ msgstr "Bilddatei auswählen"
 
 #: ../contents/ui/config/configImage.qml
 msgid "Clear"
-msgstr ""
+msgstr "Löschen"
 
 #: ../contents/ui/config/configImage.qml
 msgid "Mirror Image:"
@@ -65,7 +70,7 @@ msgstr "Geschwindigkeit:"
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Random Idle:"
-msgstr ""
+msgstr "Zufällige Untätigkeit:"
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Idle Probability (%):"
@@ -81,7 +86,7 @@ msgstr "Lautstärke:"
 
 #: ../contents/ui/config/configSound.qml
 msgid "Test"
-msgstr ""
+msgstr "Testen"
 
 #: ../contents/ui/config/configSound.qml
 msgid "Custom sound:"

--- a/package/translate/po/en.po
+++ b/package/translate/po/en.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: en\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/es.po
+++ b/package/translate/po/es.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: es\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Spanish\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/fr.po
+++ b/package/translate/po/fr.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: fr\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: French\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/it.po
+++ b/package/translate/po/it.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: it\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Italian\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/ja.po
+++ b/package/translate/po/ja.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: ja\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Japanese\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"
@@ -69,7 +74,7 @@ msgstr "ランダム待機："
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Idle Probability (%):"
-msgstr "アイドル確率（％）："
+msgstr "待機確率（％）："
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Image Flipping Based on the Direction:"

--- a/package/translate/po/ko.po
+++ b/package/translate/po/ko.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: ko\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Korean\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"
@@ -53,7 +58,7 @@ msgstr "좌우 반전:"
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Overall Movement:"
-msgstr "이동:"
+msgstr "전체 움직임:"
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Enabled"
@@ -85,11 +90,11 @@ msgstr "테스트"
 
 #: ../contents/ui/config/configSound.qml
 msgid "Custom sound:"
-msgstr "사용자 지정 소리:"
+msgstr "사용자 지정 효과음:"
 
 #: ../contents/ui/config/configSound.qml
 msgid "Path to custom sound file"
-msgstr "사용자 지정 소리 파일 경로"
+msgstr "사용자 지정 효과음 파일 경로"
 
 #: ../contents/ui/config/configSound.qml
 msgid "Browse..."

--- a/package/translate/po/pt.po
+++ b/package/translate/po/pt.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: pt\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Portuguese\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/ru.po
+++ b/package/translate/po/ru.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: ru\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Russian\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"

--- a/package/translate/po/zh.po
+++ b/package/translate/po/zh.po
@@ -6,6 +6,11 @@ msgstr ""
 "Language: zh_CN\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2026-06-26 17:55+0900\n"
+"Last-Translator: Attacktive <tribute2pantera@gmail.com>\n"
+"Language-Team: Chinese (Simplified)\n"
+"MIME-Version: 1.0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: ../contents/config/config.qml ../contents/ui/config/configImage.qml
 msgid "Image"
@@ -69,7 +74,7 @@ msgstr "随机待机："
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Idle Probability (%):"
-msgstr "空闲概率（%）："
+msgstr "待机概率（%）："
 
 #: ../contents/ui/config/configMovement.qml
 msgid "Image Flipping Based on the Direction:"


### PR DESCRIPTION
The first release whose `.plasmoid` actually carries translations (#59 landed in #76), now also **complete, consistent, and warning-free**.

### Translation polish (all 10 catalogs)
- **Completeness** — filled the 3 blank German strings (`Clear`, `Random Idle:`, `Test`) → German now 26/26, matching the others.
- **Consistency** — one term per concept per language:
  - ja: idle → **待機** everywhere (was mixed with アイドル, which reads as "idol")
  - zh: idle → **待机** everywhere (was mixed with 空闲)
  - ko: movement → **움직임**, sound → **효과음** everywhere
- **Clean headers** — backfilled `MIME-Version`, `PO-Revision-Date`, `Last-Translator`, `Language-Team`, and per-language `Plural-Forms`, so `msgfmt -c` is silent on all 10.

### Release
- Version `2.0.0` → `2.0.1`.

Verified: `msgfmt -c` → 0 warnings, every catalog 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)